### PR TITLE
Update risk scoring model with INFINITE supply type weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package includes all sorts of tooling for the Hedera NFT ecosystem, includi
 
 1. **HIP412 metadata validation:** Verify your metadata against the [HIP412 metadata standard](https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-412.md) for NFTs, which returns errors and warnings against the standard.
 2. **Local metadata validator:** Verify a local folder containing multiple JSON metadata files against the standard before publishing the NFT collection on the Hedera network. 
-3. **Risk score calculation:** Calculate a risk score for a token from the token information or by passing a token ID of an NFT on the Hedera testnet or mainnet. 
+3. **Risk score calculation:** Calculate a risk score for an NFT collection from the token information or by passing a token ID of an NFT on the Hedera testnet or mainnet.
 4. **Rarity score calculation:** Calculate the rarity scores for a local folder containing multiple JSON metadata files for an NFT collection. 
 
 

--- a/README.md
+++ b/README.md
@@ -222,18 +222,23 @@ See: **[/examples/local-metadata-validator/index.js](https://github.com/hashgrap
 
 Calculate risk score for a token from the token information or by passing a token ID of an NFT on the Hedera testnet or mainnet. 
 
-The total risk score is calculated based on the presence of certain keys for the token. Each key type has an associated weight.
+The total risk score is calculated based on the presence of certain `keys` for the token or the presence of an `INFINITE` `supply_type`. Each key or property has an associated weight.
 
 ```js
 const defaultWeights = {
-  admin_key: 200,
-  wipe_key: 200,
-  freeze_key: 50,
-  supply_key: 20,
-  kyc_key: 50,
-  pause_key: 50,
-  fee_schedule_key: 40
-}
+  keys: {
+    admin_key: 200,
+    wipe_key: 200,
+    freeze_key: 50,
+    supply_key: 20,
+    kyc_key: 50,
+    pause_key: 50,
+    fee_schedule_key: 40
+  },
+  properties: {
+    supply_type_infinite: 20
+  }
+};
 ```
 
 To determine the risk level, there are four categories each with an attached score. If the score is lower than or equal to a risk level, it will get that risk level. E.g. a token with a risk score of 200 will get a `HIGH` risk level. 

--- a/risk/index.js
+++ b/risk/index.js
@@ -21,13 +21,18 @@ const axios = require("axios");
 
 // Default weights for risk score calculation
 const defaultWeights = {
-  admin_key: 200,
-  wipe_key: 200,
-  freeze_key: 50,
-  supply_key: 20,
-  kyc_key: 50,
-  pause_key: 50,
-  fee_schedule_key: 40
+  keys: {
+    admin_key: 200,
+    wipe_key: 200,
+    freeze_key: 50,
+    supply_key: 20,
+    kyc_key: 50,
+    pause_key: 50,
+    fee_schedule_key: 40
+  },
+  properties: {
+    supply_type_infinite: 20
+  }
 };
 
 // Default thresholds for risk level calculation
@@ -50,10 +55,14 @@ const calculateRiskScoreFromData = (metadata) => {
   // Iterate through the properties of the object
   for (const key in metadata) {
     // Check if the property is present in the weights object and not null
-    if (metadata[key] && key in defaultWeights) {
+    if (metadata[key] && key in defaultWeights.keys) {
       // If it is, add the associated risk weight to the risk score
-      riskScore += defaultWeights[key];
+      riskScore += defaultWeights.keys[key];
     }
+  }
+
+  if (metadata.supply_type === "INFINITE") {
+    riskScore += defaultWeights.properties.supply_type_infinite;
   }
 
   const riskLevel = calculateRiskLevel(riskScore)
@@ -82,10 +91,14 @@ const calculateRiskScoreFromTokenId = async (tokenId, network = "mainnet") => {
     // Iterate through the properties of the object
     for (const key in metadata) {
       // Check if the property is present in the weights object and not null
-      if (metadata[key] && key in defaultWeights) {
+      if (metadata[key] && key in defaultWeights.keys) {
         // If it is, add the associated risk weight to the risk score
-        riskScore += defaultWeights[key];
+        riskScore += defaultWeights.keys[key];
       }
+    }
+
+    if (metadata.supply_type === "INFINITE") {
+      riskScore += defaultWeights.properties.supply_type_infinite;
     }
   
     const riskLevel = calculateRiskLevel(riskScore)

--- a/tests/risk/data/all-keys-token.json
+++ b/tests/risk/data/all-keys-token.json
@@ -1,0 +1,60 @@
+{
+    "admin_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "auto_renew_account": "0.0.784037",
+    "auto_renew_period": 7776000,
+    "created_timestamp": "1663272359.743907659",
+    "custom_fees": {
+      "created_timestamp": "1663272359.743907659",
+      "fixed_fees": [],
+      "royalty_fees": [
+        {
+          "all_collectors_are_exempt": false,
+          "amount": { "numerator": 5, "denominator": 100 },
+          "collector_account_id": "0.0.607666"
+        }
+      ]
+    },
+    "decimals": "0",
+    "deleted": false,
+    "expiry_timestamp": 1671048359743907659,
+    "fee_schedule_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "freeze_default": false,
+    "freeze_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "initial_supply": "0",
+    "kyc_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "max_supply": "2331",
+    "memo": "",
+    "modified_timestamp": "1663276335.852057651",
+    "name": "Hash Crabs Gen 2.0",
+    "pause_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "pause_status": "NOT_APPLICABLE",
+    "supply_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "supply_type": "INFINITE",
+    "symbol": "HASH CRABS GEN 2.0",
+    "token_id": "0.0.1270555",
+    "total_supply": "777",
+    "treasury_account_id": "0.0.784037",
+    "type": "NON_FUNGIBLE_UNIQUE",
+    "wipe_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    }
+  }

--- a/tests/risk/data/no-risk-token.json
+++ b/tests/risk/data/no-risk-token.json
@@ -1,0 +1,39 @@
+{
+  "admin_key": null,
+  "auto_renew_account": "0.0.784037",
+  "auto_renew_period": 7776000,
+  "created_timestamp": "1663272359.743907659",
+  "custom_fees": {
+    "created_timestamp": "1663272359.743907659",
+    "fixed_fees": [],
+    "royalty_fees": [
+      {
+        "all_collectors_are_exempt": false,
+        "amount": { "numerator": 5, "denominator": 100 },
+        "collector_account_id": "0.0.607666"
+      }
+    ]
+  },
+  "decimals": "0",
+  "deleted": false,
+  "expiry_timestamp": 1671048359743907659,
+  "fee_schedule_key": null,
+  "freeze_default": false,
+  "freeze_key": null,
+  "initial_supply": "0",
+  "kyc_key": null,
+  "max_supply": "2331",
+  "memo": "",
+  "modified_timestamp": "1663276335.852057651",
+  "name": "Hash Crabs Gen 2.0",
+  "pause_key": null,
+  "pause_status": "NOT_APPLICABLE",
+  "supply_key": null,
+  "supply_type": "FINITE",
+  "symbol": "HASH CRABS GEN 2.0",
+  "token_id": "0.0.1270555",
+  "total_supply": "777",
+  "treasury_account_id": "0.0.784037",
+  "type": "NON_FUNGIBLE_UNIQUE",
+  "wipe_key": null
+}

--- a/tests/risk/data/supply-key-token.json
+++ b/tests/risk/data/supply-key-token.json
@@ -1,0 +1,42 @@
+{
+    "admin_key": null,
+    "auto_renew_account": "0.0.784037",
+    "auto_renew_period": 7776000,
+    "created_timestamp": "1663272359.743907659",
+    "custom_fees": {
+      "created_timestamp": "1663272359.743907659",
+      "fixed_fees": [],
+      "royalty_fees": [
+        {
+          "all_collectors_are_exempt": false,
+          "amount": { "numerator": 5, "denominator": 100 },
+          "collector_account_id": "0.0.607666"
+        }
+      ]
+    },
+    "decimals": "0",
+    "deleted": false,
+    "expiry_timestamp": 1671048359743907659,
+    "fee_schedule_key": null,
+    "freeze_default": false,
+    "freeze_key": null,
+    "initial_supply": "0",
+    "kyc_key": null,
+    "max_supply": "2331",
+    "memo": "",
+    "modified_timestamp": "1663276335.852057651",
+    "name": "Hash Crabs Gen 2.0",
+    "pause_key": null,
+    "pause_status": "NOT_APPLICABLE",
+    "supply_key": {
+        "_type": "ED25519",
+        "key": "49efa5f54192470706914df50f17472f6f2310b8476293822e0d49b313ca2875"
+    },
+    "supply_type": "FINITE",
+    "symbol": "HASH CRABS GEN 2.0",
+    "token_id": "0.0.1270555",
+    "total_supply": "777",
+    "treasury_account_id": "0.0.784037",
+    "type": "NON_FUNGIBLE_UNIQUE",
+    "wipe_key": null
+  }

--- a/tests/risk/index.test.js
+++ b/tests/risk/index.test.js
@@ -1,0 +1,78 @@
+/*-
+ *
+ * Hedera NFT Utilities
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { calculateRiskScoreFromData, calculateRiskScoreFromTokenId } = require('../../risk');
+const no_risk_token = require('./data/no-risk-token.json');
+const supply_key_token = require('./data/supply-key-token.json');
+const all_keys_token = require('./data/all-keys-token.json');
+
+describe("Risk calculation tests", () => {
+  describe("Calculate risk score from data", () => {
+    test("it should return zero risk for token with no keys and FINITE supply type", () => {
+        // Arrange && Act
+        const riskResults = calculateRiskScoreFromData(no_risk_token);
+
+        // Assert
+        expect(riskResults.riskScore).toBe(0);
+        expect(riskResults.riskLevel).toBe("NORISK");
+    });
+
+    test("it should return 20 risk for token with supply key set", () => {
+        // Arrange && Act
+        const riskResults = calculateRiskScoreFromData(supply_key_token);
+
+        // Assert
+        expect(riskResults.riskScore).toBe(20);
+        expect(riskResults.riskLevel).toBe("LOW");
+    });
+
+    test("it should return 40 risk for token with supply key set and infinite token supply", () => {
+        // Arrange
+        let supply_key_infinite_token = JSON.parse(JSON.stringify(supply_key_token));
+        supply_key_infinite_token.supply_type = "INFINITE";
+        
+        // Act
+        const riskResults = calculateRiskScoreFromData(supply_key_infinite_token);
+
+        // Assert
+        expect(riskResults.riskScore).toBe(40);
+        expect(riskResults.riskLevel).toBe("LOW");
+    });
+
+    test("it should return HIGH risk (score ) for token with supply key set and infinite token supply", () => {
+        // Arrange && Act
+        const riskResults = calculateRiskScoreFromData(all_keys_token);
+
+        // Assert
+        expect(riskResults.riskScore).toBe(630);
+        expect(riskResults.riskLevel).toBe("HIGH");
+    });
+  });
+
+  describe("Calculate risk score from token ID", () => {
+    test("it should return 20 risk for token with supply key set (ID: 0.0.1270555 on mainnet)", async () => {
+        // Arrange && Act
+        const riskResults = await calculateRiskScoreFromTokenId("0.0.1270555");
+
+        // Assert
+        expect(riskResults.riskScore).toBe(20);
+        expect(riskResults.riskLevel).toBe("LOW");
+    });
+  });
+});


### PR DESCRIPTION
**Description**:
- Update the risk scoring model to include a weight of 20 for token information which includes an INFINITE `supply_type`. 
- Add tests to verify the updated model works.