### PR TITLE
Fix risk scoring algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ See: **[/examples/local-metadata-validator/index.js](https://github.com/hashgrap
 
 Calculate risk score for a token from the token information or by passing a token ID of an NFT on the Hedera testnet or mainnet. 
 
-The total risk score is calculated based on the presence of certain `keys` for the token or the presence of an `INFINITE` `supply_type`. Each key or property has an associated weight.
+The total risk score is calculated based on the presence of certain `keys` for the token or the presence of an `INFINITE` `supply_type` in combination with a `supply_key`. Each key or property has an associated weight.
 
 ```js
 const defaultWeights = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/nft-utilities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/nft-utilities",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache License",
       "dependencies": {
         "axios": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/nft-utilities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "NFT Utilities for Hedera Hashgraph",
   "main": "index.js",
   "scripts": {

--- a/risk/index.js
+++ b/risk/index.js
@@ -61,7 +61,7 @@ const calculateRiskScoreFromData = (metadata) => {
     }
   }
 
-  if (metadata.supply_type === "INFINITE") {
+  if (metadata.supply_type === "INFINITE" && metadata.supply_key) {
     riskScore += defaultWeights.properties.supply_type_infinite;
   }
 
@@ -97,7 +97,7 @@ const calculateRiskScoreFromTokenId = async (tokenId, network = "mainnet") => {
       }
     }
 
-    if (metadata.supply_type === "INFINITE") {
+    if (metadata.supply_type === "INFINITE" && metadata.supply_key) {
       riskScore += defaultWeights.properties.supply_type_infinite;
     }
   


### PR DESCRIPTION
**Description**:
Small fix to risk scoring: Only add the 20 risk score for supply type INFINITE when the supply key is set. Otherwise, this property doesn't involve any risk when there's no supply key.