### PR TITLE
Throw error when file is lacking attributes #26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/nft-utilities",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "NFT Utilities for Hedera Hashgraph",
   "author": "Michiel Mulders",
   "license": "Apache License",

--- a/src/rarity/index.ts
+++ b/src/rarity/index.ts
@@ -96,6 +96,11 @@ const calculateRarity = (dir: string): RarityResult[] => {
 const getAttributeMap = (files: NFTFile[]): AttributeConfig[] => {
   const attributesMap: AttributeConfig[] = [];
   files.forEach((file) => {
+    if (!file.filedata.attributes)
+      throw new Error(
+        `Attributes not found in file ${file.filename}. Please ensure that your metadata file is valid.`
+      );
+
     file.filedata.attributes.forEach((attribute: Attribute) => {
       const matchedAttributeIndex = attributesMap.findIndex(
         (attributeObject) => attribute.trait_type === attributeObject.trait_type


### PR DESCRIPTION
**Description**:
After consideration, I don't think we should skip files during the rarity calculation when it's missing attributes. If this happens, something is clearly wrong with the collection and I would make the final rarity calculation invalid. From a code perspective, it's better to throw an error, which you can catch, and not calculate rarity for such a use case. 

