### PR TITLE
Add ability to calculate rarity from data

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,11 +386,36 @@ const results = calculateRarity(absolutePathToFiles);
 console.log(results)
 ```
 
+You can also avoid having to load data from files by using the `calculateRarityFromData` function.
+
+```js
+const NFTdata = [
+    {
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "attributes": [
+            { "trait_type": "Background", "value": "Yellow" },
+            { "trait_type": "Fur", "value": "Silver" },
+            { "trait_type": "Clothing", "value": "Herbal Jacket" },
+            { "trait_type": "Mouth", "value": "Smile" },
+            { "trait_type": "Sing", "value": "Sing" }
+        ]
+    }
+]
+
+const results = calculateRarityFromData(NFTdata);
+```
+
 According to token metadata JSON schema V2, the `calculateRarity` function only looks at objects in the `attributes` property that use the following format:
 
 ```
 { "trait_type": "Background", "value": "Yellow" }
-OR
+```
+
+It does not take into account attributes with the `display_type` property set, like this:
+
+```
 { "trait_type": "Background", "value": 10, "display_type": "percentage" }
 ```
 
@@ -400,7 +425,7 @@ The output interface for this function looks like this.
 
 ```json
 [
-    { "rarity": "<string> rarity score", "NFT": "<nubmer> NFT number", "filename": "<string>" },
+    { "rarity": "<string> rarity score", "NFT": "<nubmer> NFT number", "filename": "<string optional>" },
     ...
 ]
 ```
@@ -447,7 +472,9 @@ Here's a sample output. The total sum of the individual attributes is always 100
 
 ### Examples
 
-See: **[/examples/rarity-score-calculation/index.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
+See: 
+- **[/examples/rarity-score-calculation/rarity-from-files.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
+- **[/examples/rarity-score-calculation/rarity-from-data.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
 
 ## Questions or Improvement Proposals
 

--- a/examples/rarity-score-calculation/rarity-from-data.js
+++ b/examples/rarity-score-calculation/rarity-from-data.js
@@ -1,0 +1,272 @@
+/*-
+ *
+ * Hedera NFT Utilities
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { calculateRarityFromData } = require("../../dist");
+const { Parser } = require("json2csv");
+const fs = require("fs");
+
+function main() {
+  const NFTdata = [
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Fur", "value": "Gold" },
+          { "trait_type": "Clothing", "value": "Floral Jacket" },
+          { "trait_type": "Mouth", "value": "Tongue" },
+          { "trait_type": "Sing", "value": "None" }
+        ]
+    },
+    {
+        "creator": "BOOBOO",
+        "description": "BOOBOO desc",
+        "format": "HIP412@1.0.0",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Green" },
+          { "trait_type": "Fur", "value": "Gold" },
+          { "trait_type": "Clothing", "value": "Floral Jacket" },
+          { "trait_type": "Mouth", "value": "Tongue" },
+          { "trait_type": "Sing", "value": "None" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Fur", "value": "Silver" },
+          { "trait_type": "Clothing", "value": "Floral Jacket" },
+          { "trait_type": "Mouth", "value": "Smile" },
+          { "trait_type": "Sing", "value": "None" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Green" },
+          { "trait_type": "Fur", "value": "Gold" },
+          { "trait_type": "Clothing", "value": "Floral Jacket" },
+          { "trait_type": "Mouth", "value": "Smile" },
+          { "trait_type": "Sing", "value": "None" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Fur", "value": "Silver" },
+          { "trait_type": "Clothing", "value": "Herbal Jacket" },
+          { "trait_type": "Mouth", "value": "Smile" },
+          { "trait_type": "Sing", "value": "Sing" }
+        ]
+    }
+  ]
+
+  const results = calculateRarityFromData(NFTdata);
+  console.log(JSON.stringify(results, null, 4));
+
+  /* Output:
+  [
+    {
+        "attributeContributions": [
+            {
+                "trait": "Background",
+                "value": "Yellow",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Fur",
+                "value": "Gold",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Clothing",
+                "value": "Floral Jacket",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Mouth",
+                "value": "Tongue",
+                "contribution": "27.27"
+            },
+            {
+                "trait": "Sing",
+                "value": "None",
+                "contribution": "18.18"
+            }
+        ],
+        "totalRarity": "5.50",
+        "NFT": 1
+    },
+    {
+        "attributeContributions": [
+            {
+                "trait": "Background",
+                "value": "Green",
+                "contribution": "25.00"
+            },
+            {
+                "trait": "Fur",
+                "value": "Gold",
+                "contribution": "16.67"
+            },
+            {
+                "trait": "Clothing",
+                "value": "Floral Jacket",
+                "contribution": "16.67"
+            },
+            {
+                "trait": "Mouth",
+                "value": "Tongue",
+                "contribution": "25.00"
+            },
+            {
+                "trait": "Sing",
+                "value": "None",
+                "contribution": "16.67"
+            }
+        ],
+        "totalRarity": "6.00",
+        "NFT": 2
+    },
+    {
+        "attributeContributions": [
+            {
+                "trait": "Background",
+                "value": "Yellow",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Fur",
+                "value": "Silver",
+                "contribution": "27.27"
+            },
+            {
+                "trait": "Clothing",
+                "value": "Floral Jacket",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Mouth",
+                "value": "Smile",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Sing",
+                "value": "None",
+                "contribution": "18.18"
+            }
+        ],
+        "totalRarity": "5.50",
+        "NFT": 3
+    },
+    {
+        "attributeContributions": [
+            {
+                "trait": "Background",
+                "value": "Green",
+                "contribution": "27.27"
+            },
+            {
+                "trait": "Fur",
+                "value": "Gold",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Clothing",
+                "value": "Floral Jacket",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Mouth",
+                "value": "Smile",
+                "contribution": "18.18"
+            },
+            {
+                "trait": "Sing",
+                "value": "None",
+                "contribution": "18.18"
+            }
+        ],
+        "totalRarity": "5.50",
+        "NFT": 4
+    },
+    {
+        "attributeContributions": [
+            {
+                "trait": "Background",
+                "value": "Yellow",
+                "contribution": "8.70"
+            },
+            {
+                "trait": "Fur",
+                "value": "Silver",
+                "contribution": "13.04"
+            },
+            {
+                "trait": "Clothing",
+                "value": "Herbal Jacket",
+                "contribution": "34.78"
+            },
+            {
+                "trait": "Mouth",
+                "value": "Smile",
+                "contribution": "8.70"
+            },
+            {
+                "trait": "Sing",
+                "value": "Sing",
+                "contribution": "34.78"
+            }
+        ],
+        "totalRarity": "11.50",
+        "NFT": 5
+    }
+]
+*/
+}
+
+main();

--- a/examples/rarity-score-calculation/rarity-from-files.js
+++ b/examples/rarity-score-calculation/rarity-from-files.js
@@ -17,9 +17,10 @@
  * limitations under the License.
  *
  */
-const { calculateRarity } = require("../..");
+const { calculateRarity } = require("../../dist");
 const { Parser } = require("json2csv");
 const fs = require("fs");
+
 function main() {
   // Replace with absolute path to files folder
   const absolutePathToFiles =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/nft-utilities",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "NFT Utilities for Hedera Hashgraph",
   "author": "Michiel Mulders",
   "license": "Apache License",

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -56,6 +56,7 @@ export const getJSONFilesForDir = (dir: string): string[] => {
   files.forEach((file) => {
     if (path.extname(file.name) === '.json') JSONFiles.push(file.name);
   });
+  
   // eslint-disable-next-line no-console
   console.log(`Found ${JSONFiles.length} files with the .json extension`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
   calculateRiskScoreFromTokenId,
   calculateRiskLevel,
 } from './risk';
-import { calculateRarity } from './rarity';
+import { calculateRarity, calculateRarityFromData } from './rarity';
 
 import { Attribute, Localization, File, Instance, Error, Problem, ValidationResult, Schema } from './types/validator.module';
 import { NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult } from './types/rarity.module';
@@ -49,6 +49,7 @@ export {
 
   // rarity calculation
   calculateRarity,
+  calculateRarityFromData,
 
   // interfaces
   Attribute, Localization, File, Instance, Error, Problem, ValidationResult, Schema, NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult, WeightKeys, WeightProperties, Weights, KeyTypes, RiskLevels, RiskLevelTypes, Metadata, RiskResult,

--- a/src/types/rarity.module.d.ts
+++ b/src/types/rarity.module.d.ts
@@ -44,5 +44,5 @@ export interface RarityResult {
   attributeContributions: {trait: string; value: string | number; contribution: string}[];
   totalRarity: string;
   NFT: number;
-  filename: string;
+  filename?: string;
 }


### PR DESCRIPTION
**Description**:
This PR adds the ability to calculate rarity from data (`calculateRarityFromData`) instead of only being able to calculate rarity via absolute path reading files (`calculateRarity`). This is not a breaking change because it doesn't affect other interfaces. However, the `filename` property in the `RarityResult` interface has become optional because calculating rarity from data means no filenames are involved.

```ts
export interface RarityResult {
  attributeContributions: {trait: string; value: string | number; contribution: string}[];
  totalRarity: string;
  NFT: number;
  filename?: string;
}
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Example added
