### PR TITLE
Calculate trait occurrence #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This package includes all sorts of tooling for the Hedera NFT ecosystem, includi
 - **Package: [Local metadata validator](#local-validator)**
 - **Package: [Risk score calculation](#risk-score-calculation)**
 - **Package: [Rarity score calculation](#rarity-score-calculation)**
+- **Package: [Trait occurrence calculation](#trait-occurrence-calculation)**
 - **[Questions, contact us, or improvement proposals?](#questions-or-improvement-proposals)**
 - **[Support](#Support)**
 - **[Contributing](#Contributing)**

--- a/README.md
+++ b/README.md
@@ -476,6 +476,103 @@ See:
 - **[/examples/rarity-score-calculation/rarity-from-files.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
 - **[/examples/rarity-score-calculation/rarity-from-data.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
 
+## Trait occurrence calculation
+
+Calculate how often different values for a given trait occur in a collection, percentage-based.
+
+### Usage
+
+Install the package:
+
+```bash
+npm i -s @hashgraph/nft-utilities
+```
+
+Import the package into your project and get `calculateTraitOccurenceFromData` function. Next, you need to pass a JSON array containing NFT collection metadata to the function.
+
+```js
+const NFTdata = [
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Mouth", "value": "Nose" }
+        ]
+    },
+    ...
+  ]
+
+  const results = calculateTraitOccurenceFromData(NFTdata);
+```
+
+### Interface
+
+The output interface for this function looks like this.
+
+```json
+[
+    { 
+        "trait": "<string> trait name",
+        "values": [
+            { 
+                "value": "<string> single value for trait",
+                "occurrence": "<string> percentage based occurrence with 2 digits after comma"
+            },
+            ...
+        ]
+    },
+    ...
+]
+```
+
+Here's a sample output that shows the percentage of each value's occurrence for a given trait.
+
+```
+[
+    {
+        "trait": "Background",
+        "values": [
+            {
+                "value": "Yellow",
+                "occurence": "60.00"
+            },
+            {
+                "value": "Green",
+                "occurence": "40.00"
+            }
+        ]
+    },
+    {
+        "trait": "Mouth",
+        "values": [
+            {
+                "value": "Nose",
+                "occurence": "20.00"
+            },
+            {
+                "value": "Tongue",
+                "occurence": "20.00"
+            },
+            {
+                "value": "Smile",
+                "occurence": "60.00"
+            }
+        ]
+    }
+]
+```
+
+### Examples
+
+See: 
+- **[/examples/rarity-score-calculation/trait-occurrence-from-data.js](https://github.com/hashgraph/hedera-nft-utilities/tree/main/examples/rarity-score-calculation)**
+
 ## Questions or Improvement Proposals
 
 Please create an issue or PR on [this repository](https://github.com/hashgraph/hedera-nft-utilities). Make sure to join the [Hedera Discord server](https://hedera.com/discord) to ask questions or discuss improvement suggestions.

--- a/examples/rarity-score-calculation/rarity-from-data.js
+++ b/examples/rarity-score-calculation/rarity-from-data.js
@@ -18,8 +18,6 @@
  *
  */
 const { calculateRarityFromData } = require("../../dist");
-const { Parser } = require("json2csv");
-const fs = require("fs");
 
 function main() {
   const NFTdata = [

--- a/examples/rarity-score-calculation/trait-occurrence-from-data.js
+++ b/examples/rarity-score-calculation/trait-occurrence-from-data.js
@@ -91,7 +91,40 @@ function main() {
   const results = calculateTraitOccurenceFromData(NFTdata);
   console.log(JSON.stringify(results, null, 4));
 
-  /* */
+  /* Output:
+[
+    {
+        "trait": "Background",
+        "values": [
+            {
+                "value": "Yellow",
+                "occurence": "60.00"
+            },
+            {
+                "value": "Green",
+                "occurence": "40.00"
+            }
+        ]
+    },
+    {
+        "trait": "Mouth",
+        "values": [
+            {
+                "value": "Nose",
+                "occurence": "20.00"
+            },
+            {
+                "value": "Tongue",
+                "occurence": "20.00"
+            },
+            {
+                "value": "Smile",
+                "occurence": "60.00"
+            }
+        ]
+    }
+]
+*/
 }
 
 main();

--- a/examples/rarity-score-calculation/trait-occurrence-from-data.js
+++ b/examples/rarity-score-calculation/trait-occurrence-from-data.js
@@ -1,0 +1,97 @@
+/*-
+ *
+ * Hedera NFT Utilities
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { calculateTraitOccurenceFromData } = require("../../dist");
+
+function main() {
+  const NFTdata = [
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Mouth", "value": "Nose" }
+        ]
+    },
+    {
+        "creator": "BOOBOO",
+        "description": "BOOBOO desc",
+        "format": "HIP412@1.0.0",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Green" },
+          { "trait_type": "Mouth", "value": "Tongue" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Mouth", "value": "Smile" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Green" },
+          { "trait_type": "Mouth", "value": "Smile" }
+        ]
+    },
+    {
+        "creator": "HANGRY BARBOONS",
+        "description": "HANGRY BARBOONS are 4,444 unique citizens from the United Hashgraph of Planet Earth. Designed and illustrated by President HANGRY.",
+        "format": "none",
+        "name": "HANGRY BARBOON #2343",
+        "image": "ipfs://QmaHVnnp7qAmGADa3tQfWVNxxZDRmTL5r6jKrAo16mSd5y/2343.png",
+        "type": "image/png",
+        "properties": { "edition": 2343 },
+        "attributes": [
+          { "trait_type": "Background", "value": "Yellow" },
+          { "trait_type": "Mouth", "value": "Smile" }
+        ]
+    }
+  ]
+
+  const results = calculateTraitOccurenceFromData(NFTdata);
+  console.log(JSON.stringify(results, null, 4));
+
+  /* */
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/nft-utilities",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "NFT Utilities for Hedera Hashgraph",
   "author": "Michiel Mulders",
   "license": "Apache License",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,10 @@ import {
   calculateRiskScoreFromTokenId,
   calculateRiskLevel,
 } from './risk';
-import { calculateRarity, calculateRarityFromData } from './rarity';
+import { calculateRarity, calculateRarityFromData, calculateTraitOccurenceFromData } from './rarity';
 
 import { Attribute, Localization, File, Instance, Error, Problem, ValidationResult, Schema } from './types/validator.module';
-import { NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult } from './types/rarity.module';
+import { NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult, TraitOccurrence } from './types/rarity.module';
 import { WeightKeys, WeightProperties, Weights, KeyTypes, RiskLevels, RiskLevelTypes, Metadata, RiskResult } from './types/risk.module';
 
 export {
@@ -50,7 +50,8 @@ export {
   // rarity calculation
   calculateRarity,
   calculateRarityFromData,
+  calculateTraitOccurenceFromData,
 
   // interfaces
-  Attribute, Localization, File, Instance, Error, Problem, ValidationResult, Schema, NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult, WeightKeys, WeightProperties, Weights, KeyTypes, RiskLevels, RiskLevelTypes, Metadata, RiskResult,
+  Attribute, Localization, File, Instance, Error, Problem, ValidationResult, Schema, NFTFile, NFTAttribute, ValueObject, AttributeConfig, RarityResult, WeightKeys, WeightProperties, Weights, KeyTypes, RiskLevels, RiskLevelTypes, Metadata, RiskResult, TraitOccurrence,
 };

--- a/src/rarity/index.ts
+++ b/src/rarity/index.ts
@@ -23,6 +23,7 @@ import {
   AttributeConfig,
   ValueObject,
   NFTFile,
+  TraitOccurrence,
 } from '../types/rarity.module';
 import { Attribute } from '../types/validator.module';
 
@@ -196,7 +197,7 @@ const getAttributeMapData = (metadataArray: { attributes: Attribute[] }[]): Attr
  * @return {RarityResult[]} Array of objects with rarity information for each NFT
  */
 const calculateRarityFromData = (metadataArray: { attributes: Attribute[] }[]): RarityResult[] => {
-  const attributesMap = getAttributeMapData(metadataArray); // todo replace by proper function
+  const attributesMap = getAttributeMapData(metadataArray);
 
   const normalizedRarities: RarityResult[] = [];
   let normalizedCount = 1;
@@ -247,4 +248,28 @@ const calculateRarityFromData = (metadataArray: { attributes: Attribute[] }[]): 
   return normalizedRarities;
 };
 
-export { calculateRarity, calculateRarityFromData };
+const calculateTraitOccurenceFromData = (metadataArray: { attributes: Attribute[] }[]): TraitOccurrence[] => {
+  const attributesMap = getAttributeMapData(metadataArray);
+  
+  const traitOccurences: TraitOccurrence[] = [];
+
+  attributesMap.forEach((attribute) => {
+    const traitOccurence: TraitOccurrence = {
+      trait: attribute.trait_type,
+      values: [],
+    };
+
+    attribute.values.forEach((value) => {
+      traitOccurence.values.push({
+        value: value.value,
+        occurence: (value.count / metadataArray.length * 100).toFixed(2),
+      });
+    });
+
+    traitOccurences.push(traitOccurence);
+  });
+
+  return traitOccurences;
+};
+
+export { calculateRarity, calculateRarityFromData, calculateTraitOccurenceFromData };

--- a/src/types/rarity.module.d.ts
+++ b/src/types/rarity.module.d.ts
@@ -46,3 +46,11 @@ export interface RarityResult {
   NFT: number;
   filename?: string;
 }
+
+export interface TraitOccurrence {
+  trait: string;
+  values: {
+    value: string;
+    occurence: string;
+  }[];
+};


### PR DESCRIPTION
**Description**:
Add the ability to calculate the trait occurrence for each unique trait in an NFT collection. 
Closes feature request: #31 

**Checklist**

- [x] Documented in README
- [x] Example added
